### PR TITLE
Make RPC response queue exclusive #3aht10

### DIFF
--- a/lib/mq_tools.ex
+++ b/lib/mq_tools.ex
@@ -9,7 +9,10 @@ defmodule MQTools do
 
   def start(_, _) do
     conn_opts = Application.get_env(:mq_tools, :connection)
-    queue_opts = Application.get_env(:mq_tools, :queue_opts, [])
+
+    queue_opts =
+      Application.get_env(:mq_tools, :queue_opts, [])
+      |> Keyword.put(:exclusive, true)
 
     children =
       if conn_opts do


### PR DESCRIPTION
I don't think there is a use case for making the RPC response queue non-exclusive.